### PR TITLE
Fix issue with rendering pre-rendered and instant pages.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,6 +8,21 @@ function getClacks(tabId) {
     return clacks[tabId];
 };
 
+// safely hide the page action.
+function hidePageAction(tabId) {
+    if (clacks[tabId]) {
+        chrome.pageAction.hide(tabId);
+    }
+}
+
+// safely show the page action.
+function showPageAction(tabId) {
+    if (clacks[tabId]) {
+        chrome.pageAction.show(tabId);
+    }
+}
+
+
 // The main listener to check each request's headers for clacks
 chrome.webRequest.onCompleted.addListener(
     function(details) {
@@ -34,7 +49,7 @@ chrome.webRequest.onCompleted.addListener(
                 // Note from Pete: I've change += to just = to stop it repeating itself.
                 // - related to premature deletion? - don't think so...
                 clacks[details.tabId] = newClacks;
-                chrome.pageAction.show[details.tabId];
+                showPageAction(details.tabId);
                 if (DEBUG) console.log("store");
             }
         }
@@ -48,7 +63,7 @@ chrome.webNavigation.onCommitted.addListener(
     function(details) {
         if (details.transitionType !== "auto_subframe") {
             delete clacks[details.tabId];
-            chrome.pageAction.hide(details.tabId);
+            hidePageAction(details.tabId);
         }
     }
 );
@@ -64,7 +79,7 @@ chrome.runtime.onMessage.addListener(
         }
 
         // if there is a clacks entry for the loaded tab, show icon for that tab.
-        if (clacks[tabId]) chrome.pageAction.show(tabId);
+        if (clacks[tabId]) showPageAction(tabId);
         // if (DEBUG) console.log("shown: ", shown[tabId]);
 });
 


### PR DESCRIPTION
Seems like we had a typo in the webRequest.onCompleted event handler.

This caused plenty of issue but most significantly affected prerendered
and instant pages in chrome.

You can reproduce this error in multiple ways:
1. Open up chrome and type in guardian.co.uk in the address bar but don't hit enter.
2. Wait 5 seconds. (this will ensure page is prerendered in the
   background.)
3. Now hit enter.

Notice the clacks icon doesn't show up.

Since prerendered pages are hidden they have a tabId that ends up raising an error on
pageAction.show and hide. I've added safe versions of them.

This problem is significant because Google has started to add the gnu
header and nobody has noticed this because of the bug.

To check this out just search for terry pratchett on google with this
patch committed and you'll see the clacks popup.
